### PR TITLE
remove skope-rules from dependencies due to failure on python 3.10

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 32093001b384f6fcca88231abe79b359df4110f76164056e1d7428585cba0779
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: cd ./python/interpret/ && {{ PYTHON }} -m pip install . -vv
 
@@ -40,7 +40,7 @@ requirements:
     - SALib >=1.3.3
     - shap >=0.28.5
     - dill >=0.2.5
-    - skope-rules >=1.0.1
+    # - skope-rules >=1.0.1    fails on python 3.10
     - treeinterpreter >=0.2.2
     - dash >=1.0.0 # dash 2.* removed the dependencies on: dash-html-components, dash-core-components, dash-table
     - dash-core-components >=1.0.0 # dash 2.* removes the need for this dependency


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
